### PR TITLE
Fixing Bug #89

### DIFF
--- a/jsxc.lib.js
+++ b/jsxc.lib.js
@@ -258,7 +258,7 @@ var jsxc;
 
          var lastActivity = jsxc.storage.getItem('lastActivity') || 0;
 
-         if ((new Date()).getTime() - lastActivity < jsxc.options.loginTimeout) {
+         if ((new Date()).getTime() - lastActivity > jsxc.options.loginTimeout) {
             jsxc.restore = true;
          }
 


### PR DESCRIPTION
The bug was in line 276, the time check are wrong. It has to be an '<' instead of an '>'.

Bug: https://github.com/diaspora/jsxc/issues/89