### PR TITLE
Prevent duplicate usernames in chat

### DIFF
--- a/jsxc.lib.js
+++ b/jsxc.lib.js
@@ -2255,6 +2255,9 @@ var jsxc;
 
                return false;
             }
+            if ($(this).data('name').toLowerCase() === data.name.toLowerCase()) {
+               insert = true;
+            }
          });
 
          if (!insert) {


### PR DESCRIPTION
Why this was happening:

When refreshing the page the restoreRoster() is called, adding the user once. Then after reloading the roster, the user is added again. The check in this commit prevents the user from being added again if the user was already added on restoreRoster().

#104 