### PR TITLE
Show usernames instead of squares '■' #106

### DIFF
--- a/jsxc.lib.js
+++ b/jsxc.lib.js
@@ -3225,8 +3225,7 @@ var jsxc;
       rosterBuddy: '<li>\
             <div class="jsxc_avatar">☺</div>\
             <div class="jsxc_control"></div>\
-            <div class="jsxc_restore">■</div>\
-            <div id="jsxc_window_name" nameclass="jsxc_name"/>\
+            <div class="jsxc_name"/>\
             <div class="jsxc_options jsxc_right">\
                 <div class="jsxc_rename" title="%%rename_buddy%%">✎</div>\
                 <div class="jsxc_delete" title="%%delete_buddy%%">✘</div>\


### PR DESCRIPTION
Revert part of [9651e2c], see https://github.com/diaspora/jsxc/pull/98#discussion_r33545916