### PR TITLE
Make chat roster toggle bar more visible

### DIFF
--- a/scss/_roster.scss
+++ b/scss/_roster.scss
@@ -1,9 +1,9 @@
 #jsxc_roster {
     position: fixed;
-    top: 40px;
+    top: 50px;
     bottom: 0;
     right: 0;
-    width: 200px;
+    width: 220px;
     overflow: visible;
     border-left: 24px solid $roster_border_left;
     z-index: 80;


### PR DESCRIPTION
It now looks like follows:

![screen shot 2015-06-30 at 5 07 37 pm](https://cloud.githubusercontent.com/assets/6329898/8426432/a4e5f804-1f4a-11e5-9d76-bf7798a8b961.png)
