### PR TITLE
Do not print trace for getPrefix

### DIFF
--- a/src/jsxc.lib.storage.js
+++ b/src/jsxc.lib.storage.js
@@ -22,7 +22,8 @@ jsxc.storage = {
       var self = jsxc.storage;
 
       if (uk && !jsxc.bid) {
-         console.trace('Unable to create user prefix');
+         jsxc.debug('Unable to create user prefix');
+         return;
       }
 
       return self.PREFIX + self.SEP + ((uk && jsxc.bid) ? jsxc.bid + self.SEP : '');


### PR DESCRIPTION
This happens if the user has no active connection
Printing it to the debug log instead of the whole trace
reduces unnecessary noise